### PR TITLE
Fixed version command

### DIFF
--- a/cmd/adowi2gh/main.go
+++ b/cmd/adowi2gh/main.go
@@ -86,7 +86,11 @@ var versionCmd = &cobra.Command{
 	Short: "Show version information",
 	Long:  "Display the version, commit, and build time of the application.",
 	Run: func(cmd *cobra.Command, args []string) {
-		info, _ := debug.ReadBuildInfo()
+		info, ok := debug.ReadBuildInfo()
+		if !ok || info == nil {
+			fmt.Println("adowi2gh version unknown (build info not available)")
+			return
+		}
 		fmt.Printf("adowi2gh version %s\n", info.Main.Version)
 	},
 }

--- a/cmd/adowi2gh/main.go
+++ b/cmd/adowi2gh/main.go
@@ -84,7 +84,7 @@ var validateCmd = &cobra.Command{
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show version information",
-	Long:  "Display the version, commit, and build time of the application.",
+	Long:  "Display the version of the application.",
 	Run: func(cmd *cobra.Command, args []string) {
 		info, ok := debug.ReadBuildInfo()
 		if !ok || info == nil {

--- a/cmd/adowi2gh/main.go
+++ b/cmd/adowi2gh/main.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -18,11 +19,6 @@ import (
 )
 
 var (
-	// Version information - set by build flags
-	Version   = "dev"
-	Commit    = "unknown"
-	BuildTime = "unknown"
-
 	// CLI flags
 	configFile string
 	dryRun     bool
@@ -90,9 +86,8 @@ var versionCmd = &cobra.Command{
 	Short: "Show version information",
 	Long:  "Display the version, commit, and build time of the application.",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("adowi2gh version %s\n", Version)
-		fmt.Printf("Commit: %s\n", Commit)
-		fmt.Printf("Built: %s\n", BuildTime)
+		info, _ := debug.ReadBuildInfo()
+		fmt.Printf("adowi2gh version %s\n", info.Main.Version)
 	},
 }
 


### PR DESCRIPTION
This pull request updates how version information is handled and displayed in the `adowi2gh` CLI tool. Instead of relying on build flags and global variables, it now uses Go's `debug.ReadBuildInfo()` to retrieve version information at runtime.

Version information handling:

* Removed the global `Version`, `Commit`, and `BuildTime` variables that were previously set by build flags.
* Updated the `versionCmd` command to use `debug.ReadBuildInfo()` for displaying the application's version, simplifying version reporting and making it more robust.
* Added an import for the `runtime/debug` package to support reading build information.