### PR TITLE
Support Github Issue Type mapping (from DevOps work item type), plus a few small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A powerful command-line tool to migrate work items from Azure DevOps to GitHub i
 - **Full Migration Support**: Migrate work items with titles, descriptions, comments, and metadata
 - **Field Mapping**: Configurable mapping of ADO fields to GitHub issue fields
 - **State Management**: Map ADO work item states to GitHub issue states (open/closed)
+- **Type Mapping**: Map ADO work item types to GitHub issue types
 - **Label Generation**: Automatic label creation based on work item type, priority, and tags
 - **User Mapping**: Map ADO users to GitHub usernames for proper assignment
 - **Batch Processing**: Process work items in configurable batches with rate limiting
@@ -84,10 +85,16 @@ field_mapping:
     "Done": "closed"
   
   type_mapping:
-    "Bug": ["bug"]
-    "User Story": ["enhancement"]
-    "Task": ["task"]
+    "bug": ["bug"]
+    "user story": ["enhancement"]
+    "task": ["task"]
   
+  issue_type_mapping:
+    "Bug": "Bug"
+    "Product Backlog Item": "Feature"
+    "Task": "Task"
+    "User Story": "Feature"
+
   priority_mapping:
     "1": ["priority:critical"]
     "2": ["priority:high"]

--- a/cmd/adowi2gh/main.go
+++ b/cmd/adowi2gh/main.go
@@ -293,10 +293,10 @@ func createDefaultConfig() *config.Config {
 					"Done":     "closed",
 				},
 				TypeMapping: map[string][]string{
-					"Bug":        {"bug"},
-					"User Story": {"enhancement"},
-					"Task":       {"task"},
-					"Epic":       {"epic"},
+					"bug":        {"bug"},
+					"user story": {"enhancement"},
+					"task":       {"task"},
+					"epic":       {"epic"},
 				},
 				PriorityMapping: map[string][]string{
 					"1": {"priority:critical"},

--- a/cmd/adowi2gh/main.go
+++ b/cmd/adowi2gh/main.go
@@ -272,8 +272,8 @@ func createDefaultConfig() *config.Config {
 			Project:             "your-project-name",
 			Query: config.WorkItemQuery{
 				WIQL:          "",
-				WorkItemTypes: []string{"Bug", "User Story", "Task"},
-				States:        []string{"New", "Active", "Resolved"},
+				WorkItemTypes: []string{"Bug", "Epic", "Feature", "Product Backlog Item", "Task", "User Story"},
+				States:        []string{"Active", "New", "Resolved"},
 			},
 		},
 		GitHub: config.GitHubConfig{
@@ -286,23 +286,25 @@ func createDefaultConfig() *config.Config {
 			BatchSize: 50,
 			FieldMapping: config.FieldMapping{
 				StateMapping: map[string]string{
-					"New":      "open",
 					"Active":   "open",
-					"Resolved": "open",
 					"Closed":   "closed",
 					"Done":     "closed",
+					"New":      "open",
+					"Resolved": "open",
 				},
 				TypeMapping: map[string][]string{
-					"bug":        {"bug"},
-					"user story": {"enhancement"},
-					"task":       {"task"},
-					"epic":       {"epic"},
+					"bug":                  {"bug"},
+					"epic":                 {"epic"},
+					"feature":              {"feature"},
+					"product backlog item": {"enhancement"},
+					"task":                 {"task"},
+					"user story":           {"enhancement"},
 				},
 				IssueTypeMapping: map[string]string{
 					"Bug":                  "Bug",
+					"Product Backlog Item": "Feature",
 					"Task":                 "Task",
 					"User Story":           "Feature",
-					"Product Backlog Item": "Feature",
 				},
 				PriorityMapping: map[string][]string{
 					"1": {"priority:critical"},

--- a/cmd/adowi2gh/main.go
+++ b/cmd/adowi2gh/main.go
@@ -298,6 +298,12 @@ func createDefaultConfig() *config.Config {
 					"task":       {"task"},
 					"epic":       {"epic"},
 				},
+				IssueTypeMapping: map[string]string{
+					"Bug":                  "Bug",
+					"Task":                 "Task",
+					"User Story":           "Feature",
+					"Product Backlog Item": "Feature",
+				},
 				PriorityMapping: map[string][]string{
 					"1": {"priority:critical"},
 					"2": {"priority:high"},

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -107,7 +107,14 @@ query:
     - "New"
     - "Active"
     - "Done"
+    - "Closed"
+  area_paths:
+    - "ProjectName\\Feature1"
 ```
+
+Note that `area_paths` includes all items under the specified paths.
+
+If you want to include completed items then you need to add "Done" and "Closed" to the `states` filter. The default configuration only includes active work items.
 
 ### Option B: Custom WIQL Query
 ```yaml
@@ -137,11 +144,16 @@ field_mapping:
     "New": "open"
     "Active": "open"
     "Done": "closed"
-  
+
+  issue_type_mapping:
+    "Bug": "bug"
+    "User Story": "Feature"
+    "Task": "Task"
+
   type_mapping:
-    "Bug": ["bug"]
-    "User Story": ["enhancement", "user-story"]
-    "Task": ["task"]
+    "bug": ["bug"]
+    "user Story": ["enhancement", "user-story"]
+    "task": ["task"]
   
   priority_mapping:
     "1": ["priority:critical"]
@@ -149,6 +161,10 @@ field_mapping:
     "3": ["priority:medium"]
     "4": ["priority:low"]
 ```
+
+`issue_type_mapping` maps to GitHub issue type (single value).
+
+`type_mapping` maps to GitHub labels (may have multiple values).
 
 ## Step 7: Configure User Mapping
 

--- a/internal/ado/client.go
+++ b/internal/ado/client.go
@@ -153,7 +153,7 @@ func (c *Client) buildDefaultQuery() string {
 	}
 
 	if len(c.config.Query.AreaPaths) > 0 {
-		query += " AND [System.AreaPath] UNDER ("
+		query += " AND ([System.AreaPath] UNDER "
 		for i, areaPath := range c.config.Query.AreaPaths {
 			if i > 0 {
 				query += " OR [System.AreaPath] UNDER "

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,7 @@ type FieldMapping struct {
 	StateMapping         map[string]string   `yaml:"state_mapping"`
 	LabelMapping         map[string][]string `yaml:"label_mapping"`
 	TypeMapping          map[string][]string `yaml:"type_mapping"`
+	IssueTypeMapping     map[string]string   `yaml:"issue_type_mapping"`
 	PriorityMapping      map[string][]string `yaml:"priority_mapping"`
 	TimeZone             string              `yaml:"time_zone"`
 	IncludeSeverityLabel bool                `yaml:"include_severity_label"`

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -99,6 +99,10 @@ func (c *Client) CreateIssue(ctx context.Context, issue *models.GitHubIssue) (*m
 		Assignees: &issue.Assignees,
 	}
 
+	if issue.Type != "" {
+		githubIssue.Type = &issue.Type
+	}
+
 	if issue.Milestone != nil {
 		githubIssue.Milestone = issue.Milestone
 	}

--- a/internal/migration/engine.go
+++ b/internal/migration/engine.go
@@ -130,7 +130,9 @@ func (e *Engine) performDryRun(ctx context.Context, workItems []*models.WorkItem
 		e.logger.Debug("Migration details",
 			"labels", issue.Labels,
 			"assignees", issue.Assignees,
-			"state", issue.State)
+			"state", issue.State,
+		    "type", issue.Type,
+		)
 
 		e.report.SuccessfulCount++
 	}

--- a/internal/migration/mapper.go
+++ b/internal/migration/mapper.go
@@ -35,6 +35,7 @@ func (m *Mapper) MapWorkItemToIssue(workItem *models.WorkItem) (*models.GitHubIs
 		State:      m.mapState(workItem.GetState()),
 		Labels:     m.mapLabels(workItem),
 		Assignees:  m.mapAssignees(workItem),
+		Type:       m.mapIssueType(workItem.GetWorkItemType()),
 	}
 
 	// TODO: is metadata needed?
@@ -132,6 +133,15 @@ func (m *Mapper) mapLabels(workItem *models.WorkItem) []string {
 	labels = m.deduplicateLabels(labels)
 
 	return labels
+}
+
+func (m *Mapper) mapIssueType(workItemType string) string {
+	if m.config.IssueTypeMapping != nil {
+		if githubIssueType, exists := m.config.IssueTypeMapping[workItemType]; exists {
+			return githubIssueType
+		}
+	}
+	return ""
 }
 
 func (m *Mapper) mapAssignees(workItem *models.WorkItem) []string {

--- a/internal/models/github.go
+++ b/internal/models/github.go
@@ -10,6 +10,7 @@ type GitHubIssue struct {
 	Title      string                 `json:"title"`
 	Body       string                 `json:"body"`
 	State      string                 `json:"state"`
+	Type       string                 `json:"type,omitempty"`
 	Labels     []string               `json:"labels"`
 	Assignees  []string               `json:"assignees"`
 	Milestone  *int                   `json:"milestone,omitempty"`


### PR DESCRIPTION
Fixes issues #23, #24, #25, and #29.

#23 is fixed by changing the default `config init` to be lowercase (as the code converts to lower case before looking up the mapping). Mapping of work item type -> label now works.

#24 fixes the WIQL syntax for (under) area path, but putting the bracket in the right spot. It supports both single area path (under) and multiple.

#25 adds support for GitHub issue Type, mapping from the DevOps work item type. Note that the config is similar to State mapping and looks up the fields as they are, so needs to have correct title capitalisation in the config. (This is inconsistent with label handling, but consistent with state handling).

If the work item type is not in the mapping, then no type is sent to github (it will be empty).

Update documentation for the new configuration items.

#29 adds some extra work item types to the default filter, and to the type to label mapping (Product Backlog Item, Feature, and Epic).

Product Backlog Item is the equivalent of User Story in some of the other DevOps standard templates. This change does add Feature and Epic to the work item types migrated by default.

It leaves the default configuration at only migrating active items (i.e. not Closed or Done items). The user needs to make a deliberate configuration decision to include completed items.
